### PR TITLE
Fix minor issues in the English docs

### DIFF
--- a/hugo-site/content/en/readme/page-2.md
+++ b/hugo-site/content/en/readme/page-2.md
@@ -8,7 +8,7 @@ To install this theme via the community store, navigate to  `Settings > Appearan
 
 1. Under `Themes`, click Manage
 
-2. `Type "Flexcyon in the search bar > Select it > Click "Install and Use"`
+2. `Type "Flexcyon" in the search bar > Select it > Click "Install and Use"`
 
 ## Via BRAT
 

--- a/hugo-site/content/en/styling/CSS-Classes/heading-indicators/page-4.md
+++ b/hugo-site/content/en/styling/CSS-Classes/heading-indicators/page-4.md
@@ -16,4 +16,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/headings#enable-heading-indicators-globally-for-heading-3).
+The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/headings#enable-heading-indicators-globally-for-heading-4).

--- a/hugo-site/content/en/styling/Callout-Metadata/combined-styling/page-25.md
+++ b/hugo-site/content/en/styling/Callout-Metadata/combined-styling/page-25.md
@@ -9,6 +9,6 @@ Callout metadata: "font-interface-all"
 > The text font will also use interface font
 ```
 
-> Shorthand for both ["font-inteface-content"](../content-styling/page-15)
+> Shorthand for both ["font-interface-content"](../content-styling/page-15)
 > and ["font-interface-title"](../title-styling/page-31)
 

--- a/hugo-site/content/en/styling/Callout-Metadata/list-styling/_index.md
+++ b/hugo-site/content/en/styling/Callout-Metadata/list-styling/_index.md
@@ -24,7 +24,8 @@ To write an ordered list in Obsidian, use:
 
 To write an unordered list in Obsidian. use:
 
-```md6- Never
+```md
+- Never
 - Gonna
 - Give
 - ...

--- a/hugo-site/content/en/styling/Callout-Metadata/title-styling/page-1.md
+++ b/hugo-site/content/en/styling/Callout-Metadata/title-styling/page-1.md
@@ -8,7 +8,7 @@ Usage:
 
 ```md
 > [!info|no-title] This title will not show
-> Content wil show as usual
+> Content will show as usual
 ```
 
 The style itself is also applied to ["empty"](../combined-styling/page-1)

--- a/hugo-site/content/en/styling/Style-Settings/Editor/Table/_index.md
+++ b/hugo-site/content/en/styling/Style-Settings/Editor/Table/_index.md
@@ -81,7 +81,7 @@ Options:
 - Medium (UI Font size)
 - Large (UI Font size)
 
-<span style="font-size: large;">Sample table header</span>
+<span style="font-size: large;">Sample table cell</span>
 
 ### Table Cell Vertical Padding
 CSS Variable(s) targeted: `var(--flexcyon-td-verti-padding)`


### PR DESCRIPTION
Fixes a few minor issues I came across in the English docs while working on the Korean translation (#6). Each is in its own commit.

## Changes

- **Typos** — `font-inteface-content` → `font-interface-content` (combined-styling/page-25), and `Content wil show` → `Content will show` (title-styling/page-1).
- **Broken code fence** — in list-styling/_index.md the unordered-list example had ` ```md6- Never ` on one line, so the code block didn't render. Split it into the fence and the list items.
- **Wrong heading anchor** — heading-indicators/page-4.md linked to `#enable-heading-indicators-globally-for-heading-3` on an H4 page; corrected to `heading-4`.
- **Missing closing quote** — readme/page-2.md had `Type "Flexcyon in the search bar`; added the closing quote (`"Flexcyon"`).
- **Wrong sample text** — Table/_index.md had `Sample table header` in the Table Cell section (line 84); changed to `Sample table cell` to match the section. The Table header section (line 51) is unchanged.

`hugo build` passes clean.

Note: the Korean translation (#6) faithfully followed the pre-fix English source, so some of these (the typo, the broken fence, the wrong anchor) are present there too. Once this is merged I'll add a follow-up commit to #6 to bring it in line.