### PR TITLE
feat(i18n): add OneVth to Korean credits

### DIFF
--- a/hugo-site/content/ko/credits/_index.md
+++ b/hugo-site/content/ko/credits/_index.md
@@ -47,5 +47,9 @@ flexcyon에 기여하는 데 관심이 있다면 [기여하기](../contributing)
 
 - Obsidian 멤버 그룹 디스코드의 `@Melvin`은 div를 가운데 정렬하는 방법과 함께 테마에 대한 피드백 및 제안을
 
+## 번역
+
+- Obsidian 멤버 그룹 디스코드의 `@Onev`(@OneVth on GitHub)는 한국어 문서 번역을
+
 ___
 마지막으로, 테마를 사용해주시고 문서를 읽어주신 *당신*께 감사드립니다 :D

--- a/hugo-site/content/ko/credits/_index.md
+++ b/hugo-site/content/ko/credits/_index.md
@@ -15,7 +15,7 @@ flexcyon에 기여하는 데 관심이 있다면 [기여하기](../contributing)
 
 - vaykinov와 wizentex가 만든 [Ukiyo](https://github.com/technerium/obsidian-ukiyo) 테마는 팝업 Callout에 대해
 
-- Obsidian 멤버 그룹 디스코드의 `@Kapirklaa`(@ElsaTam on GitHub)는 배경 이미지 코드 조각에 대해
+- Obsidian 멤버 그룹 디스코드의 `@Kapirklaa`(GitHub의 @ElsaTam)는 배경 이미지 코드 조각에 대해
 
 - Obsidian 멤버 그룹 디스코드의 `@Nuno`는 탭 애니메이션 코드 조각에 대해
 
@@ -31,7 +31,7 @@ flexcyon에 기여하는 데 관심이 있다면 [기여하기](../contributing)
 
 - Obsidian 멤버 그룹 디스코드의 `@TundraMoonlight`는 TUI 부가 기능에 대한 영감을
 
-- Obsidian 멤버 그룹 디스코드의 `@Kapirklaa`(@ElsaTam on GitHub)는 Callout Metadata 유틸리티에 대한 영감을
+- Obsidian 멤버 그룹 디스코드의 `@Kapirklaa`(GitHub의 @ElsaTam)는 Callout Metadata 유틸리티에 대한 영감을
 
 - Obsidian 멤버 그룹 디스코드의 `@BEN10`은 문서화와 Powerlevel10k 레이아웃 수정에 대해
 
@@ -49,7 +49,7 @@ flexcyon에 기여하는 데 관심이 있다면 [기여하기](../contributing)
 
 ## 번역
 
-- Obsidian 멤버 그룹 디스코드의 `@Onev`(@OneVth on GitHub)는 한국어 문서 번역을
+- Obsidian 멤버 그룹 디스코드의 `@Onev`(GitHub의 @OneVth)는 한국어 문서 번역을
 
 ___
 마지막으로, 테마를 사용해주시고 문서를 읽어주신 *당신*께 감사드립니다 :D


### PR DESCRIPTION
Adds myself to the Korean credits, per #8.

Follows the existing credits convention (Discord handle + GitHub handle), placed under a new `## 번역` (Translations) section before the closing line.