### PR TITLE
fix(docs): repair broken internal links across en/zh

### DIFF
--- a/hugo-site/content/en/readme/page-2.md
+++ b/hugo-site/content/en/readme/page-2.md
@@ -29,5 +29,5 @@ To install this theme via BRAT, navigate to `Settings > Community Plugins > Brow
 Installation of Style Settings is highly recommended for this theme, as most
 customisation and functionality is built around it.
 
-Documentation for style settings of this theme can be found [here](../styling/style-settings)
+Documentation for style settings of this theme can be found [here](../../styling/style-settings)
 

--- a/hugo-site/content/en/styling/callout-metadata/bg-styling/page-10.md
+++ b/hugo-site/content/en/styling/callout-metadata/bg-styling/page-10.md
@@ -11,9 +11,9 @@ Usage:
 > The background color will be the color mix of red and blue colors of this theme
 ```
 
-The style itself is also applied to ["all-color1-color2"](../combined-styling/page-10)
-along with ["title-color1-color2"](../title-styling/page-10).
+The style itself is also applied to ["all-color1-color2"](../../combined-styling/page-10)
+along with ["title-color1-color2"](../../title-styling/page-10).
 
-Requires [this Style Settings option](../../../style-settings/editor/accent-colors#enable-extended-color-palette) 
+Requires [this Style Settings option](../../../style-settings/editor/colors/accent-colors#enable-extended-color-palette) 
 to be on.
 

--- a/hugo-site/content/en/styling/callout-metadata/bg-styling/page-2.md
+++ b/hugo-site/content/en/styling/callout-metadata/bg-styling/page-2.md
@@ -9,6 +9,6 @@ Callout metadata: "bg-blue"
 > The background color will be blue
 ```
 
-The style itself is also applied to ["all-blue"](../combined-styling/page-2)
-along with ["title-blue"](../title-styling/page-2).
+The style itself is also applied to ["all-blue"](../../combined-styling/page-2)
+along with ["title-blue"](../../title-styling/page-2).
 

--- a/hugo-site/content/en/styling/callout-metadata/bg-styling/page-3.md
+++ b/hugo-site/content/en/styling/callout-metadata/bg-styling/page-3.md
@@ -9,6 +9,6 @@ Callout metadata: "bg-red"
 > The background color will be red
 ```
 
-The style itself is also applied to ["all-red"](../combined-styling/page-3)
-along with ["title-red"](../title-styling/page-3).
+The style itself is also applied to ["all-red"](../../combined-styling/page-3)
+along with ["title-red"](../../title-styling/page-3).
 

--- a/hugo-site/content/en/styling/callout-metadata/bg-styling/page-4.md
+++ b/hugo-site/content/en/styling/callout-metadata/bg-styling/page-4.md
@@ -9,6 +9,6 @@ Callout metadata: "bg-purple"
 > The background color will be purple
 ```
 
-The style itself is also applied to ["all-purple"](../combined-styling/page-4)
-along with ["title-purple"](../title-styling/page-4).
+The style itself is also applied to ["all-purple"](../../combined-styling/page-4)
+along with ["title-purple"](../../title-styling/page-4).
 

--- a/hugo-site/content/en/styling/callout-metadata/bg-styling/page-5.md
+++ b/hugo-site/content/en/styling/callout-metadata/bg-styling/page-5.md
@@ -9,6 +9,6 @@ Callout metadata: "bg-cyan"
 > The background color will be cyan
 ```
 
-The style itself is also applied to ["all-cyan"](../combined-styling/page-5)
-along with ["title-cyan"](../title-styling/page-5).
+The style itself is also applied to ["all-cyan"](../../combined-styling/page-5)
+along with ["title-cyan"](../../title-styling/page-5).
 

--- a/hugo-site/content/en/styling/callout-metadata/bg-styling/page-6.md
+++ b/hugo-site/content/en/styling/callout-metadata/bg-styling/page-6.md
@@ -9,6 +9,6 @@ Callout metadata: "bg-pink"
 > The background color will be pink
 ```
 
-The style itself is also applied to ["all-pink"](../combined-styling/page-6)
-along with ["title-pink"](../title-styling/page-6).
+The style itself is also applied to ["all-pink"](../../combined-styling/page-6)
+along with ["title-pink"](../../title-styling/page-6).
 

--- a/hugo-site/content/en/styling/callout-metadata/bg-styling/page-7.md
+++ b/hugo-site/content/en/styling/callout-metadata/bg-styling/page-7.md
@@ -9,6 +9,6 @@ Callout metadata: "bg-green"
 > The background color will be green
 ```
 
-The style itself is also applied to ["all-green"](../combined-styling/page-7)
-along with ["title-green"](../title-styling/page-7).
+The style itself is also applied to ["all-green"](../../combined-styling/page-7)
+along with ["title-green"](../../title-styling/page-7).
 

--- a/hugo-site/content/en/styling/callout-metadata/bg-styling/page-8.md
+++ b/hugo-site/content/en/styling/callout-metadata/bg-styling/page-8.md
@@ -9,6 +9,6 @@ Callout metadata: "bg-orange"
 > The background color will be orange
 ```
 
-The style itself is also applied to ["all-orange"](../combined-styling/page-8)
-along with ["title-orange"](../title-styling/page-8).
+The style itself is also applied to ["all-orange"](../../combined-styling/page-8)
+along with ["title-orange"](../../title-styling/page-8).
 

--- a/hugo-site/content/en/styling/callout-metadata/bg-styling/page-9.md
+++ b/hugo-site/content/en/styling/callout-metadata/bg-styling/page-9.md
@@ -9,6 +9,6 @@ Callout metadata: "bg-yellow"
 > The background color will be yellow
 ```
 
-The style itself is also applied to ["all-yellow"](../combined-styling/page-9)
-along with ["title-yellow"](../title-styling/page-9).
+The style itself is also applied to ["all-yellow"](../../combined-styling/page-9)
+along with ["title-yellow"](../../title-styling/page-9).
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-1.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-1.md
@@ -18,6 +18,6 @@ Alternatively, you can use:
 > Content is shown as usual
 ```
 
-> Shorthand for both ["no-icon"](../icon-styling/page-1)
-> and ["no-title"](../title-styling/page-1)
+> Shorthand for both ["no-icon"](../../icon-styling/page-1)
+> and ["no-title"](../../title-styling/page-1)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-10.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-10.md
@@ -12,7 +12,7 @@ this theme
 > The background color will be the color mix of red and blue colors of this theme
 ```
 
-> Shorthand for both ["bg-color1-color2"](../bg-styling/page-10) and ["title-color1-color2"](../title-styling/page-10)
+> Shorthand for both ["bg-color1-color2"](../../bg-styling/page-10) and ["title-color1-color2"](../../title-styling/page-10)
 
 You can also use this colors in your own css snippets, they take the form of:
 
@@ -20,5 +20,5 @@ You can also use this colors in your own css snippets, they take the form of:
 > - `var(--color-color1-color2-mix-bg)`: E.g. `var(--color-red-blue-mix-bg)`
 
 
-Requires [this Style Settings option](../../../style-settings/editor/accent-colors#enable-extended-color-palette) 
+Requires [this Style Settings option](../../../style-settings/editor/colors/accent-colors#enable-extended-color-palette) 
 to be on

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-11.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-11.md
@@ -11,5 +11,5 @@ Usage:
 > The content will be displayed as rtl
 ```
 
-> Shorthand for both ["rtl-content"](../content-styling/page-1)
-> and ["rtl-title"](../title-styling/page-11)
+> Shorthand for both ["rtl-content"](../../content-styling/page-1)
+> and ["rtl-title"](../../title-styling/page-11)

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-12.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-12.md
@@ -11,5 +11,5 @@ Usage:
 > The content will be displayed as ltr
 ```
 
-> Shorthand for both ["ltr-content"](../content-styling/page-2) 
-> and ["ltr-title"](../title-styling/page-12)
+> Shorthand for both ["ltr-content"](../../content-styling/page-2) 
+> and ["ltr-title"](../../title-styling/page-12)

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-13.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-13.md
@@ -11,5 +11,5 @@ Usage:
 > The content will be displayed as center
 ```
 
-> Shorthand for both ["center-content"](../content-styling/page-3) 
-> and ["center-title"](../title-styling/page-13)
+> Shorthand for both ["center-content"](../../content-styling/page-3) 
+> and ["center-title"](../../title-styling/page-13)

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-14.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-14.md
@@ -11,5 +11,5 @@ Usage:
 > The content will be displayed as uppercase
 ```
 
-> Shorthand for both ["uppercase-content"](../content-styling/page-4) 
-> and ["uppercase-title"](../title-styling/page-14)
+> Shorthand for both ["uppercase-content"](../../content-styling/page-4) 
+> and ["uppercase-title"](../../title-styling/page-14)

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-15.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-15.md
@@ -11,5 +11,5 @@ Usage:
 > The content will be displayed as lowercase
 ```
 
-> Shorthand for both ["lowercase-content"](../content-styling/page-5) 
-> and ["lowercase-title"](../title-styling/page-15)
+> Shorthand for both ["lowercase-content"](../../content-styling/page-5) 
+> and ["lowercase-title"](../../title-styling/page-15)

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-16.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-16.md
@@ -14,5 +14,5 @@ Usage:
 > The content will be displayed as caps
 ```
 
-> Shorthand for both ["caps-content"](../content-styling/page-6) 
-> and ["caps-title"](../title-styling/page-16)
+> Shorthand for both ["caps-content"](../../content-styling/page-6) 
+> and ["caps-title"](../../title-styling/page-16)

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-17.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-17.md
@@ -11,5 +11,5 @@ Usage:
 > The content will be tilted
 ```
 
-> Shorthand for both ["tilt-content"](../content-styling/page-7) 
-> and ["uppercase-title"](../title-styling/page-17)
+> Shorthand for both ["tilt-content"](../../content-styling/page-7) 
+> and ["uppercase-title"](../../title-styling/page-17)

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-18.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-18.md
@@ -11,5 +11,5 @@ Usage:
 > The content will be displayed as italic
 ```
 
-> Shorthand for both ["italic-content"](../content-styling/page-8) 
-> and ["italic-title"](../title-styling/page-18)
+> Shorthand for both ["italic-content"](../../content-styling/page-8) 
+> and ["italic-title"](../../title-styling/page-18)

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-19.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-19.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as oblique
 ```
 
-> Shorthand for both ["oblique-content"](../content-styling/page-9)
-> and ["oblique-title"](../title-styling/page-19)
+> Shorthand for both ["oblique-content"](../../content-styling/page-9)
+> and ["oblique-title"](../../title-styling/page-19)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-2.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-2.md
@@ -9,6 +9,6 @@ Callout metadata: "all-blue"
 > The background color will be blue
 ```
 
-> Shorthand for both ["bg-blue"](../bg-styling/page-2)
-> and ["title-blue"](../title-styling/page-2)
+> Shorthand for both ["bg-blue"](../../bg-styling/page-2)
+> and ["title-blue"](../../title-styling/page-2)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-20.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-20.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as dashed
 ```
 
-> Shorthand for both ["dashed-content"](../content-styling/page-10)
-> and ["dashed-title"](../title-styling/page-20)
+> Shorthand for both ["dashed-content"](../../content-styling/page-10)
+> and ["dashed-title"](../../title-styling/page-20)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-21.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-21.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as overline
 ```
 
-> Shorthand for both ["overline-content"](../content-styling/page-11)
-> and ["overline-title"](../title-styling/page-21)
+> Shorthand for both ["overline-content"](../../content-styling/page-11)
+> and ["overline-title"](../../title-styling/page-21)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-22.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-22.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as underline
 ```
 
-> Shorthand for both ["underline-content"](../content-styling/page-12)
-> and ["underline-title"](../title-styling/page-22)
+> Shorthand for both ["underline-content"](../../content-styling/page-12)
+> and ["underline-title"](../../title-styling/page-22)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-23.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-23.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as line-through
 ```
 
-> Shorthand for both ["line-through-content"](../content-styling/page-13)
-> and ["line-through-title"](../title-styling/page-23)
+> Shorthand for both ["line-through-content"](../../content-styling/page-13)
+> and ["line-through-title"](../../title-styling/page-23)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-24.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-24.md
@@ -18,6 +18,6 @@ Usage:
 > Content will have a lighter font weight
 ```
 
-> Shorthand for both ["w-`value`-content"](../content-styling/page-14)
-> and ["w-`value`-title"](../title-styling/page-24)
+> Shorthand for both ["w-`value`-content"](../../content-styling/page-14)
+> and ["w-`value`-title"](../../title-styling/page-24)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-25.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-25.md
@@ -9,6 +9,6 @@ Callout metadata: "font-interface-all"
 > The text font will also use interface font
 ```
 
-> Shorthand for both ["font-interface-content"](../content-styling/page-15)
-> and ["font-interface-title"](../title-styling/page-31)
+> Shorthand for both ["font-interface-content"](../../content-styling/page-15)
+> and ["font-interface-title"](../../title-styling/page-31)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-26.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-26.md
@@ -9,6 +9,6 @@ Callout metadata: "font-text-all"
 > The text font will also use text font
 ```
 
-> Shorthand for both ["font-text-content"](../content-styling/page-16)
-> and ["font-text-title"](../title-styling/page-32)
+> Shorthand for both ["font-text-content"](../../content-styling/page-16)
+> and ["font-text-title"](../../title-styling/page-32)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-27.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-27.md
@@ -9,6 +9,6 @@ Callout metadata: "font-monospace-all"
 > The text font will also use monospace font
 ```
 
-> Shorthand for both ["font-monospace-content"](../content-styling/page-17)
-> and ["font-monospace-title"](../title-styling/page-33)
+> Shorthand for both ["font-monospace-content"](../../content-styling/page-17)
+> and ["font-monospace-title"](../../title-styling/page-33)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-3.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-3.md
@@ -9,6 +9,6 @@ Callout metadata: "all-red"
 > The background color will be red
 ```
 
-> Shorthand for both ["bg-red"](../bg-styling/page-3)
-> and ["title-red"](../title-styling/page-3)
+> Shorthand for both ["bg-red"](../../bg-styling/page-3)
+> and ["title-red"](../../title-styling/page-3)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-4.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-4.md
@@ -9,6 +9,6 @@ Callout metadata: "all-purple"
 > The background color will be purple
 ```
 
-> Shorthand for both ["bg-purple"](../bg-styling/page-4)
-> and ["title-purple"](../title-styling/page-4)
+> Shorthand for both ["bg-purple"](../../bg-styling/page-4)
+> and ["title-purple"](../../title-styling/page-4)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-5.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-5.md
@@ -9,6 +9,6 @@ Callout metadata: "all-cyan"
 > The background color will be cyan
 ```
 
-> Shorthand for both ["bg-cyan"](../bg-styling/page-5)
-> and ["title-cyan"](../title-styling/page-5)
+> Shorthand for both ["bg-cyan"](../../bg-styling/page-5)
+> and ["title-cyan"](../../title-styling/page-5)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-6.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-6.md
@@ -9,6 +9,6 @@ Callout metadata: "all-pink"
 > The background color will be pink
 ```
 
-> Shorthand for both ["bg-pink"](../bg-styling/page-6)
-> and ["title-pink"](../title-styling/page-6)
+> Shorthand for both ["bg-pink"](../../bg-styling/page-6)
+> and ["title-pink"](../../title-styling/page-6)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-7.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-7.md
@@ -9,6 +9,6 @@ Callout metadata: "all-green"
 > The background color will be green
 ```
 
-> Shorthand for both ["bg-green"](../bg-styling/page-7)
-> and ["title-green"](../title-styling/page-7)
+> Shorthand for both ["bg-green"](../../bg-styling/page-7)
+> and ["title-green"](../../title-styling/page-7)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-8.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-8.md
@@ -9,6 +9,6 @@ Callout metadata: "all-orange"
 > The background color will be orange
 ```
 
-> Shorthand for both ["bg-orange"](../bg-styling/page-8)
-> and ["title-orange"](../title-styling/page-8)
+> Shorthand for both ["bg-orange"](../../bg-styling/page-8)
+> and ["title-orange"](../../title-styling/page-8)
 

--- a/hugo-site/content/en/styling/callout-metadata/combined-styling/page-9.md
+++ b/hugo-site/content/en/styling/callout-metadata/combined-styling/page-9.md
@@ -9,6 +9,6 @@ Callout metadata: "all-yellow"
 > The background color will be yellow
 ```
 
-> Shorthand for both ["bg-yellow"](../bg-styling/page-9)
-> and ["title-yellow"](../title-styling/page-9)
+> Shorthand for both ["bg-yellow"](../../bg-styling/page-9)
+> and ["title-yellow"](../../title-styling/page-9)
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-1.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-1.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as rtl
 ```
 
-The style itself is also applied to ["rtl-all"](../combined-styling/page-11)
-along with ["rtl-title"](../title-styling/page-11)
+The style itself is also applied to ["rtl-all"](../../combined-styling/page-11)
+along with ["rtl-title"](../../title-styling/page-11)
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-10.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-10.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as dashed
 ```
 
-The style itself is also applied to ["dashed-all"](../combined-styling/page-20)
-along with ["dashed-title"](../title-styling/page-20).
+The style itself is also applied to ["dashed-all"](../../combined-styling/page-20)
+along with ["dashed-title"](../../title-styling/page-20).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-11.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-11.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as overline
 ```
 
-The style itself is also applied to ["overline-all"](../combined-styling/page-21)
-along with ["overline-title"](../title-styling/page-21).
+The style itself is also applied to ["overline-all"](../../combined-styling/page-21)
+along with ["overline-title"](../../title-styling/page-21).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-12.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-12.md
@@ -10,4 +10,4 @@ Usage:
 > The content will be displayed as underline
 ```
 
-The style itself is also applied to ["underline-all"](../combined-styling/page-22) along with ["underline-title"](../title-styling/page-22).
+The style itself is also applied to ["underline-all"](../../combined-styling/page-22) along with ["underline-title"](../../title-styling/page-22).

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-13.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-13.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as strikethrough
 ```
 
-The style itself is also applied to ["line-through-all"](../combined-styling/page-23)
-along with ["line-through-title"](../title-styling/page-23).
+The style itself is also applied to ["line-through-all"](../../combined-styling/page-23)
+along with ["line-through-title"](../../title-styling/page-23).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-14.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-14.md
@@ -18,6 +18,6 @@ Usage:
 > Content will have a bold font weight
 ```
 
-The style itself is also applied to ["w-`value`-all"](../combined-styling/page-24)
-along with ["w-`value`-title"](../title-styling/page-24).
+The style itself is also applied to ["w-`value`-all"](../../combined-styling/page-24)
+along with ["w-`value`-title"](../../title-styling/page-24).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-15.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-15.md
@@ -9,6 +9,6 @@ Callout metadata: "font-interface-content"
 > The text font will use the interface font
 ```
 
-The style itself is also applied to ["font-interface-all"](../combined-styling/page-25)
-along with ["font-interface-title"](../title-styling/page-31).
+The style itself is also applied to ["font-interface-all"](../../combined-styling/page-25)
+along with ["font-interface-title"](../../title-styling/page-31).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-16.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-16.md
@@ -9,6 +9,6 @@ Callout metadata: "font-text-content"
 > The text font will use the text font
 ```
 
-The style itself is also applied to ["font-text-all"](../combined-styling/page-26)
-along with ["font-text-title"](../title-styling/page-32).
+The style itself is also applied to ["font-text-all"](../../combined-styling/page-26)
+along with ["font-text-title"](../../title-styling/page-32).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-17.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-17.md
@@ -9,6 +9,6 @@ Callout metadata: "font-monospace-content"
 > The text font will use the monospace font
 ```
 
-The style itself is also applied to ["font-monospace-all"](../combined-styling/page-27)
-along with ["font-monospace-title"](../title-styling/page-33).
+The style itself is also applied to ["font-monospace-all"](../../combined-styling/page-27)
+along with ["font-monospace-title"](../../title-styling/page-33).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-2.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-2.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as ltr
 ```
 
-The style itself is also applied to ["ltr-all"](../combined-styling/page-12)
-along with ["ltr-title"](../title-styling/page-12).
+The style itself is also applied to ["ltr-all"](../../combined-styling/page-12)
+along with ["ltr-title"](../../title-styling/page-12).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-3.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-3.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be centered
 ```
 
-The style itself is also applied to ["center-all"](../combined-styling/page-13)
-along with ["center-title"](../title-styling/page-13).
+The style itself is also applied to ["center-all"](../../combined-styling/page-13)
+along with ["center-title"](../../title-styling/page-13).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-4.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-4.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as uppercase
 ```
 
-The style itself is also applied to ["uppercase-all"](../combined-styling/page-14)
-along with ["uppercase-title"](../title-styling/page-14).
+The style itself is also applied to ["uppercase-all"](../../combined-styling/page-14)
+along with ["uppercase-title"](../../title-styling/page-14).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-5.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-5.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as lowercase
 ```
 
-The style itself is also applied to ["lowercase-all"](../combined-styling/page-15)
-along with ["lowercase-title"](../title-styling/page-15).
+The style itself is also applied to ["lowercase-all"](../../combined-styling/page-15)
+along with ["lowercase-title"](../../title-styling/page-15).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-6.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-6.md
@@ -14,5 +14,5 @@ Usage:
 > The content will be displayed as caps
 ```
 
-The style itself is also applied to ["caps-all"](../combined-styling/page-16)
-along with ["caps-title"](../title-styling/page-16).
+The style itself is also applied to ["caps-all"](../../combined-styling/page-16)
+along with ["caps-title"](../../title-styling/page-16).

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-7.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-7.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be tilted
 ```
 
-The style itself is also applied to ["tilt-all"](../combined-styling/page-17)
-along with ["tilt-title"](../title-styling/page-17).
+The style itself is also applied to ["tilt-all"](../../combined-styling/page-17)
+along with ["tilt-title"](../../title-styling/page-17).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-8.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-8.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as italic
 ```
 
-The style itself is also applied to ["italic-all"](../combined-styling/page-18)
-along with ["italic-title"](../title-styling/page-18).
+The style itself is also applied to ["italic-all"](../../combined-styling/page-18)
+along with ["italic-title"](../../title-styling/page-18).
 

--- a/hugo-site/content/en/styling/callout-metadata/content-styling/page-9.md
+++ b/hugo-site/content/en/styling/callout-metadata/content-styling/page-9.md
@@ -11,6 +11,6 @@ Usage:
 > The content will be displayed as oblique
 ```
 
-The style itself is also applied to ["oblique-all"](../combined-styling/page-19)
-along with ["oblique-title"](../title-styling/page-19).
+The style itself is also applied to ["oblique-all"](../../combined-styling/page-19)
+along with ["oblique-title"](../../title-styling/page-19).
 

--- a/hugo-site/content/en/styling/callout-metadata/flashcard.md
+++ b/hugo-site/content/en/styling/callout-metadata/flashcard.md
@@ -12,5 +12,5 @@ Usage:
 > which will show on hover
 ```
 
-[Click here](../../../style-settings/editor/callouts#flashcard-callout)
+[Click here](../../style-settings/editor/callouts#flashcard-callout)
 for configuration options.

--- a/hugo-site/content/en/styling/callout-metadata/font-size.md
+++ b/hugo-site/content/en/styling/callout-metadata/font-size.md
@@ -12,7 +12,7 @@ Custom Callout / Callout Metadata:
 
 Options: Smaller, Small, Medium, Large
 
-Configure in  [UI Font Size](../../../style-settings/editor/ui-font-size) settings
+Configure in  [UI Font Size](../../style-settings/editor/typography/ui-font-size) settings
 
 Usage:
 

--- a/hugo-site/content/en/styling/callout-metadata/icon-styling/page-1.md
+++ b/hugo-site/content/en/styling/callout-metadata/icon-styling/page-1.md
@@ -16,6 +16,6 @@ Usage:
 > Content
 ```
 
-The style itself is also applied to ["empty"](../combined-styling/page-1)
-along with ["no-title"](../title-styling/page-1).
+The style itself is also applied to ["empty"](../../combined-styling/page-1)
+along with ["no-title"](../../title-styling/page-1).
 

--- a/hugo-site/content/en/styling/callout-metadata/popup.md
+++ b/hugo-site/content/en/styling/callout-metadata/popup.md
@@ -12,5 +12,5 @@ Usage:
 > in reading mode, which will show its contents on hover
 ```
 
-[Click here](../../../style-settings/editor/callouts#popup-callout)
+[Click here](../../style-settings/editor/callouts#popup-callout)
 for configuration options.

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-1.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-1.md
@@ -11,6 +11,6 @@ Usage:
 > Content will show as usual
 ```
 
-The style itself is also applied to ["empty"](../combined-styling/page-1)
-along with ["no-icon"](../icon-styling/page-1).
+The style itself is also applied to ["empty"](../../combined-styling/page-1)
+along with ["no-icon"](../../icon-styling/page-1).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-10.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-10.md
@@ -13,8 +13,8 @@ this theme
 ```
 
 The style itself is also applied to
-["all-color1-color2"](../combined-styling/page-10) along with ["bg-color1-color2"](../bg-styling/page-10).
+["all-color1-color2"](../../combined-styling/page-10) along with ["bg-color1-color2"](../../bg-styling/page-10).
 
-Requires [this Style Settings option](../../../style-settings/editor/accent-colors#enable-extended-color-palette)
+Requires [this Style Settings option](../../../style-settings/editor/colors/accent-colors#enable-extended-color-palette)
 to be on
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-11.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-11.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["rtl-all"](../combined-styling/page-11)
-along with ["rtl-content"](../content-styling/page-1).
+The style itself is also applied to ["rtl-all"](../../combined-styling/page-11)
+along with ["rtl-content"](../../content-styling/page-1).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-12.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-12.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["ltr-all"](../combined-styling/page-12)
-along with ["ltr-content"](../content-styling/page-2).
+The style itself is also applied to ["ltr-all"](../../combined-styling/page-12)
+along with ["ltr-content"](../../content-styling/page-2).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-13.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-13.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["center-all"](../combined-styling/page-13)
-along with ["center-content"](../content-styling/page-3).
+The style itself is also applied to ["center-all"](../../combined-styling/page-13)
+along with ["center-content"](../../content-styling/page-3).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-14.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-14.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["uppercase-all"](../combined-styling/page-14)
-along with ["uppercase-content"](../content-styling/page-4).
+The style itself is also applied to ["uppercase-all"](../../combined-styling/page-14)
+along with ["uppercase-content"](../../content-styling/page-4).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-15.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-15.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["lowercase-all"](../combined-styling/page-14)
-along with ["lowercase-content"](../content-styling/page-4).
+The style itself is also applied to ["lowercase-all"](../../combined-styling/page-14)
+along with ["lowercase-content"](../../content-styling/page-4).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-16.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-16.md
@@ -14,6 +14,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["caps-all"](../combined-styling/page-16)
-along with ["caps-content"](../content-styling/page-6).
+The style itself is also applied to ["caps-all"](../../combined-styling/page-16)
+along with ["caps-content"](../../content-styling/page-6).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-17.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-17.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["tilt-all"](../combined-styling/page-17)
-along with ["tilt-content"](../content-styling/page-7).
+The style itself is also applied to ["tilt-all"](../../combined-styling/page-17)
+along with ["tilt-content"](../../content-styling/page-7).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-18.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-18.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["italic-all"](../combined-styling/page-18)
-along with ["italic-content"](../content-styling/page-8).
+The style itself is also applied to ["italic-all"](../../combined-styling/page-18)
+along with ["italic-content"](../../content-styling/page-8).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-19.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-19.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["oblique-all"](../combined-styling/page-19)
-along with ["oblique-content"](../content-styling/page-9).
+The style itself is also applied to ["oblique-all"](../../combined-styling/page-19)
+along with ["oblique-content"](../../content-styling/page-9).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-2.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-2.md
@@ -9,6 +9,6 @@ Callout metadata: "title-blue"
 > The background color will display as usual
 ```
 
-The style itself is also applied to ["all-blue"](../combined-styling/page-2) 
-along with ["bg-blue"](../bg-styling/page-2).
+The style itself is also applied to ["all-blue"](../../combined-styling/page-2) 
+along with ["bg-blue"](../../bg-styling/page-2).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-20.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-20.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["dashed-all"](../combined-styling/page-20)
-along with ["dashed-content"](../content-styling/page-10).
+The style itself is also applied to ["dashed-all"](../../combined-styling/page-20)
+along with ["dashed-content"](../../content-styling/page-10).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-21.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-21.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["overline-all"](../combined-styling/page-21)
-along with ["overline-content"](../content-styling/page-11).
+The style itself is also applied to ["overline-all"](../../combined-styling/page-21)
+along with ["overline-content"](../../content-styling/page-11).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-22.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-22.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["underline-all"](../combined-styling/page-22)
-along with ["underline-content"](../content-styling/page-12).
+The style itself is also applied to ["underline-all"](../../combined-styling/page-22)
+along with ["underline-content"](../../content-styling/page-12).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-23.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-23.md
@@ -11,6 +11,6 @@ Usage:
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["line-through-all"](../combined-styling/page-23)
-along with ["line-through-content"](../content-styling/page-13).
+The style itself is also applied to ["line-through-all"](../../combined-styling/page-23)
+along with ["line-through-content"](../../content-styling/page-13).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-24.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-24.md
@@ -19,6 +19,6 @@ reading mode/reading mode
 > Content is shown as usual
 ```
 
-The style itself is also applied to ["w-`value`-all"](../combined-styling/page-24)
-along with ["w-`value`-content"](../content-styling/page-14).
+The style itself is also applied to ["w-`value`-all"](../../combined-styling/page-24)
+along with ["w-`value`-content"](../../content-styling/page-14).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-3.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-3.md
@@ -9,6 +9,6 @@ Callout metadata: "title-red"
 > The background color will display as usual
 ```
 
-The style itself is also applied to ["all-red"](../combined-styling/page-3)
-along with ["bg-red"](../bg-styling/page-3).
+The style itself is also applied to ["all-red"](../../combined-styling/page-3)
+along with ["bg-red"](../../bg-styling/page-3).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-31.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-31.md
@@ -9,6 +9,6 @@ Callout metadata: "font-interface-title"
 > The text font will display as usual
 ```
 
-The style itself is also applied to ["font-interface-all"](../combined-styling/page-25)
-along with ["font-interface-content"](../content-styling/page-15).
+The style itself is also applied to ["font-interface-all"](../../combined-styling/page-25)
+along with ["font-interface-content"](../../content-styling/page-15).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-32.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-32.md
@@ -9,6 +9,6 @@ Callout metadata: "font-text-title"
 > The text font will display as usual
 ```
 
-The style itself is also applied to ["font-text-all"](../combined-styling/page-26)
-along with ["font-text-content"](../content-styling/page-16).
+The style itself is also applied to ["font-text-all"](../../combined-styling/page-26)
+along with ["font-text-content"](../../content-styling/page-16).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-33.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-33.md
@@ -9,5 +9,5 @@ Callout metadata: "font-monospace-title"
 > The text font will display as usual
 ```
 
-The style itself is also applied to ["font-monospace-all"](../combined-styling/page-27)
-along with ["font-monospace-content"](../content-styling/page-17).
+The style itself is also applied to ["font-monospace-all"](../../combined-styling/page-27)
+along with ["font-monospace-content"](../../content-styling/page-17).

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-4.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-4.md
@@ -9,6 +9,6 @@ Callout metadata: "title-purple"
 > The background color will display as usual
 ```
 
-The style itself is also applied to ["all-purple"](../combined-styling/page-4)
-along with ["bg-purple"](../bg-styling/page-4).
+The style itself is also applied to ["all-purple"](../../combined-styling/page-4)
+along with ["bg-purple"](../../bg-styling/page-4).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-5.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-5.md
@@ -9,6 +9,6 @@ Callout metadata: "title-cyan"
 > The background color will display as usual
 ```
 
-The style itself is also applied to ["all-cyan"](../combined-styling/page-5)
-along with ["bg-cyan"](../bg-styling/page-5).
+The style itself is also applied to ["all-cyan"](../../combined-styling/page-5)
+along with ["bg-cyan"](../../bg-styling/page-5).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-6.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-6.md
@@ -9,6 +9,6 @@ Callout metadata: "title-pink"
 > The background color will display as usual
 ```
 
-The style itself is also applied to ["all-pink"](../combined-styling/page-6)
-along with ["bg-pink"](../bg-styling/page-6).
+The style itself is also applied to ["all-pink"](../../combined-styling/page-6)
+along with ["bg-pink"](../../bg-styling/page-6).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-7.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-7.md
@@ -9,6 +9,6 @@ Callout metadata: "title-green"
 > The background color will display as usual
 ```
 
-The style itself is also applied to ["all-green"](../combined-styling/page-7)
-along with ["bg-green"](../bg-styling/page-7).
+The style itself is also applied to ["all-green"](../../combined-styling/page-7)
+along with ["bg-green"](../../bg-styling/page-7).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-8.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-8.md
@@ -9,6 +9,6 @@ Callout metadata: "title-orange"
 > The background color will display as usual
 ```
 
-The style itself is also applied to ["all-orange"](../combined-styling/page-8)
-along with ["bg-orange"](../bg-styling/page-8).
+The style itself is also applied to ["all-orange"](../../combined-styling/page-8)
+along with ["bg-orange"](../../bg-styling/page-8).
 

--- a/hugo-site/content/en/styling/callout-metadata/title-styling/page-9.md
+++ b/hugo-site/content/en/styling/callout-metadata/title-styling/page-9.md
@@ -9,6 +9,6 @@ Callout metadata: "title-yellow"
 > The background color will display as usual
 ```
 
-The style itself is also applied to ["all-yellow"](../combined-styling/page-9)
-along with ["bg-yellow"](../bg-styling/page-9).
+The style itself is also applied to ["all-yellow"](../../combined-styling/page-9)
+along with ["bg-yellow"](../../bg-styling/page-9).
 

--- a/hugo-site/content/en/styling/css-classes/heading-indicators/_index.md
+++ b/hugo-site/content/en/styling/css-classes/heading-indicators/_index.md
@@ -20,5 +20,5 @@ cssclasses:
 ###### I will have an indicator before me
 ```
 
-For a Style Settings equivalent which enables this option globally. [Click here](../../../style-settings/editor/headings#about-enable-heading-indicators-globally).
+For a Style Settings equivalent which enables this option globally. [Click here](../../style-settings/editor/typography/headings#about-enable-heading-indicators-globally).
 

--- a/hugo-site/content/en/styling/css-classes/heading-indicators/page-1.md
+++ b/hugo-site/content/en/styling/css-classes/heading-indicators/page-1.md
@@ -16,4 +16,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/headings#enable-heading-indicators-globally-for-heading-1).
+The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/typography/headings#enable-heading-indicators-globally-for-heading-1).

--- a/hugo-site/content/en/styling/css-classes/heading-indicators/page-2.md
+++ b/hugo-site/content/en/styling/css-classes/heading-indicators/page-2.md
@@ -16,4 +16,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/headings#enable-heading-indicators-globally-for-heading-2).
+The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/typography/headings#enable-heading-indicators-globally-for-heading-2).

--- a/hugo-site/content/en/styling/css-classes/heading-indicators/page-3.md
+++ b/hugo-site/content/en/styling/css-classes/heading-indicators/page-3.md
@@ -16,4 +16,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/headings#enable-heading-indicators-globally-for-heading-3).
+The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/typography/headings#enable-heading-indicators-globally-for-heading-3).

--- a/hugo-site/content/en/styling/css-classes/heading-indicators/page-4.md
+++ b/hugo-site/content/en/styling/css-classes/heading-indicators/page-4.md
@@ -16,4 +16,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/headings#enable-heading-indicators-globally-for-heading-4).
+The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/typography/headings#enable-heading-indicators-globally-for-heading-4).

--- a/hugo-site/content/en/styling/css-classes/heading-indicators/page-5.md
+++ b/hugo-site/content/en/styling/css-classes/heading-indicators/page-5.md
@@ -16,4 +16,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/headings#enable-heading-indicators-globally-for-heading-5).
+The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/typography/headings#enable-heading-indicators-globally-for-heading-5).

--- a/hugo-site/content/en/styling/css-classes/heading-indicators/page-6.md
+++ b/hugo-site/content/en/styling/css-classes/heading-indicators/page-6.md
@@ -16,4 +16,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/headings#enable-heading-indicators-globally-for-heading-6).
+The Style Settings equivalent to enabling this globally can be [found here](../../../style-settings/editor/typography/headings#enable-heading-indicators-globally-for-heading-6).

--- a/hugo-site/content/en/styling/style-settings/editor/Typography/headings/_index.md
+++ b/hugo-site/content/en/styling/style-settings/editor/Typography/headings/_index.md
@@ -34,7 +34,7 @@ Default: false (class toggle)
 ### About Enable heading indicators globally
 
 Customise which headings have heading indicators before them globally.
-If you are looking to apply them on a per-note basis, [click here](../../../css-classes/heading-indicators)
+If you are looking to apply them on a per-note basis, [click here](../../../../css-classes/heading-indicators)
 
 ___
 ## Heading 1
@@ -45,7 +45,7 @@ CSS Variable(s) targeted: `var(--flexcyon-headings-indicator-h1)`
 
 Default: false (class toggle)
 
-> The CSS Class equivalent can be [found here](../../../css-classes/heading-indicators/page-1)
+> The CSS Class equivalent can be [found here](../../../../css-classes/heading-indicators/page-1)
 
 ### Heading 1 Colour
 
@@ -118,7 +118,7 @@ CSS Variable(s) targeted: `var(--flexcyon-headings-indicator-h2)`
 
 Default: false (class toggle)
 
-> The CSS Class equivalent can be [found here](../../../css-classes/heading-indicators/page-2)
+> The CSS Class equivalent can be [found here](../../../../css-classes/heading-indicators/page-2)
 
 ### Heading 2 Colour
 
@@ -190,7 +190,7 @@ CSS Variable(s) targeted: `var(--flexcyon-headings-indicator-h3)`
 
 Default: false (class toggle)
 
-> The CSS Class equivalent can be [found here](../../../css-classes/heading-indicators/page-3)
+> The CSS Class equivalent can be [found here](../../../../css-classes/heading-indicators/page-3)
 
 ### Heading 3 Colour
 
@@ -262,7 +262,7 @@ CSS Variable(s) targeted: `var(--flexcyon-headings-indicator-h4)`
 
 Default: false (class toggle)
 
-> The CSS Class equivalent can be [found here](../../../css-classes/heading-indicators/page-4)
+> The CSS Class equivalent can be [found here](../../../../css-classes/heading-indicators/page-4)
 
 ### Heading 4 Colour
 
@@ -334,7 +334,7 @@ CSS Variable(s) targeted: `var(--flexcyon-headings-indicator-h5)`
 
 Default: false (class toggle)
 
-> The CSS Class equivalent can be [found here](../../../css-classes/heading-indicators/page-5)
+> The CSS Class equivalent can be [found here](../../../../css-classes/heading-indicators/page-5)
 
 ### Heading 5 Colour
 
@@ -406,7 +406,7 @@ CSS Variable(s) targeted: `var(--flexcyon-headings-indicator-h6)`
 
 Default: false (class toggle)
 
-> The CSS Class equivalent can be [found here](../../../css-classes/heading-indicators/page-6)
+> The CSS Class equivalent can be [found here](../../../../css-classes/heading-indicators/page-6)
 
 ### Heading 6 Colour
 

--- a/hugo-site/content/zh/readme/page-2.md
+++ b/hugo-site/content/zh/readme/page-2.md
@@ -28,4 +28,4 @@ title: 下载
 
 强烈建议为此主题安装 `Style Settings` 插件, 因为大多数定制和功能都是围绕它构建的. 
 
-[单击此处](../styling/style-settings) 查看此主题样式设置的文档
+[单击此处](../../styling/style-settings) 查看此主题样式设置的文档

--- a/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-10.md
+++ b/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-10.md
@@ -11,6 +11,6 @@ title: 扩展调色板 - 背景
 > The background color will be the color mix of red and blue colors of this theme
 ```
 
-这种风格本身也适用于 ["all-color1-color2"](../combined-styling/page-10) 和 ["title-color1-color2"](../title-styling/page-10).
+这种风格本身也适用于 ["all-color1-color2"](../../combined-styling/page-10) 和 ["title-color1-color2"](../../title-styling/page-10).
 
-需要启用此 ["样式设置" 选项](../../../style-settings/editor/accent-colors#启用扩展调色板).
+需要启用此 ["样式设置" 选项](../../../style-settings/editor/colors/accent-colors#启用扩展调色板).

--- a/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-2.md
+++ b/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-2.md
@@ -9,4 +9,4 @@ Callout 元数据: "bg-blue"
 > The background color will be blue
 ```
 
-这种风格本身也适用于 ["all-blue"](../combined-styling/page-2) 和 ["title-blue"](../title-styling/page-2). 
+这种风格本身也适用于 ["all-blue"](../../combined-styling/page-2) 和 ["title-blue"](../../title-styling/page-2). 

--- a/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-3.md
+++ b/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-3.md
@@ -9,4 +9,4 @@ Callout 元数据: "bg-red"
 > The background color will be red
 ```
 
-这种风格本身也适用于 ["all-red"](../combined-styling/page-3) 和 ["title-red"](../title-styling/page-3). 
+这种风格本身也适用于 ["all-red"](../../combined-styling/page-3) 和 ["title-red"](../../title-styling/page-3). 

--- a/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-4.md
+++ b/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-4.md
@@ -9,4 +9,4 @@ Callout 元数据: "bg-purple"
 > The background color will be purple
 ```
 
-这种风格本身也适用于 ["all-purple"](../combined-styling/page-4) 和 ["title-purple"](../title-styling/page-4). 
+这种风格本身也适用于 ["all-purple"](../../combined-styling/page-4) 和 ["title-purple"](../../title-styling/page-4). 

--- a/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-5.md
+++ b/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-5.md
@@ -9,4 +9,4 @@ Callout 元数据: "bg-cyan"
 > The background color will be cyan
 ```
 
-这种风格本身也适用于 ["all-cyan"](../combined-styling/page-5) 和 ["title-cyan"](../title-styling/page-5). 
+这种风格本身也适用于 ["all-cyan"](../../combined-styling/page-5) 和 ["title-cyan"](../../title-styling/page-5). 

--- a/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-6.md
+++ b/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-6.md
@@ -9,4 +9,4 @@ Callout 元数据: "bg-pink"
 > The background color will be pink
 ```
 
-这种风格本身也适用于 ["all-pink"](../combined-styling/page-6) 和 ["title-pink"](../title-styling/page-6). 
+这种风格本身也适用于 ["all-pink"](../../combined-styling/page-6) 和 ["title-pink"](../../title-styling/page-6). 

--- a/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-7.md
+++ b/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-7.md
@@ -9,4 +9,4 @@ Callout 元数据: "bg-green"
 > The background color will be green
 ```
 
-这种风格本身也适用于 ["all-green"](../combined-styling/page-7) 和 ["title-green"](../title-styling/page-7). 
+这种风格本身也适用于 ["all-green"](../../combined-styling/page-7) 和 ["title-green"](../../title-styling/page-7). 

--- a/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-8.md
+++ b/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-8.md
@@ -9,4 +9,4 @@ Callout 元数据: "bg-orange"
 > The background color will be orange
 ```
 
-这种风格本身也适用于 ["all-orange"](../combined-styling/page-8) 和 ["title-orange"](../title-styling/page-8). 
+这种风格本身也适用于 ["all-orange"](../../combined-styling/page-8) 和 ["title-orange"](../../title-styling/page-8). 

--- a/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-9.md
+++ b/hugo-site/content/zh/styling/callout-metadata/bg-styling/page-9.md
@@ -9,4 +9,4 @@ Callout 元数据: "bg-yellow"
 > The background color will be yellow
 ```
 
-这种风格本身也适用于 ["all-yellow"](../combined-styling/page-9) 和 ["title-yellow"](../title-styling/page-9). 
+这种风格本身也适用于 ["all-yellow"](../../combined-styling/page-9) 和 ["title-yellow"](../../title-styling/page-9). 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-1.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-1.md
@@ -17,5 +17,5 @@ Callout 元数据: "empty"
 > [!info|empty] Neither the title and callout icon will show
 > Content is shown as usual
 ```
-> ["no-icon"](../icon-styling/page-1) 和 ["no-title"](../title-styling/page-1) 的简写
+> ["no-icon"](../../icon-styling/page-1) 和 ["no-title"](../../title-styling/page-1) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-10.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-10.md
@@ -12,11 +12,11 @@ this theme
 > The background color will be the color mix of red and blue colors of this theme
 ```
 
-> ["bg-color1-color2"](../bg-styling/page-10) 和 ["title-color1-color2"](../title-styling/page-10) 的简写
+> ["bg-color1-color2"](../../bg-styling/page-10) 和 ["title-color1-color2"](../../title-styling/page-10) 的简写
 
 您也可以在自己的 CSS 代码片段中使用这些颜色, 它们的形式如下：
 
 > - `var(--color-color1-color2-mix)`: E.g. `var(--color-red-blue-mix)`
 > - `var(--color-color1-color2-mix-bg)`: E.g. `var(--color-red-blue-mix-bg)`
 
-需要启用此 ["样式设置" 选项](../../../style-settings/editor/accent-colors#启用扩展调色板).
+需要启用此 ["样式设置" 选项](../../../style-settings/editor/colors/accent-colors#启用扩展调色板).

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-11.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-11.md
@@ -11,5 +11,5 @@ Callout 元数据: "rtl-all"
 > The content will be displayed as rtl
 ```
 
-> ["rtl-content"](../content-styling/page-1) 和 ["rtl-title"](../title-styling/page-11) 的简写
+> ["rtl-content"](../../content-styling/page-1) 和 ["rtl-title"](../../title-styling/page-11) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-12.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-12.md
@@ -11,5 +11,5 @@ Callout 元数据: "ltr-all"
 > The content will be displayed as ltr
 ```
 
-> ["ltr-content"](../content-styling/page-2) 和 ["ltr-title"](../title-styling/page-12) 的简写
+> ["ltr-content"](../../content-styling/page-2) 和 ["ltr-title"](../../title-styling/page-12) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-13.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-13.md
@@ -11,5 +11,5 @@ Callout 元数据: "center-all"
 > The content will be displayed as center
 ```
 
-> ["center-content"](../content-styling/page-3) 和 ["center-title"](../title-styling/page-13) 的简写
+> ["center-content"](../../content-styling/page-3) 和 ["center-title"](../../title-styling/page-13) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-14.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-14.md
@@ -11,5 +11,5 @@ Callout 元数据: "uppercase-all"
 > The content will be displayed as uppercase
 ```
 
-> ["uppercase-content"](../content-styling/page-4) 和 ["uppercase-title"](../title-styling/page-14) 的简写
+> ["uppercase-content"](../../content-styling/page-4) 和 ["uppercase-title"](../../title-styling/page-14) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-15.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-15.md
@@ -11,5 +11,5 @@ Callout 元数据: "lowercase-all"
 > The content will be displayed as lowercase
 ```
 
-> ["lowercase-content"](../content-styling/page-5) 和 ["lowercase-title"](../title-styling/page-15) 的简写
+> ["lowercase-content"](../../content-styling/page-5) 和 ["lowercase-title"](../../title-styling/page-15) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-16.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-16.md
@@ -14,5 +14,5 @@ Callout 元数据: "caps-all"/"capitalize-all"
 > The content will be displayed as caps
 ```
 
-> ["caps-content"](../content-styling/page-6) 和 ["caps-title"](../title-styling/page-16) 的简写
+> ["caps-content"](../../content-styling/page-6) 和 ["caps-title"](../../title-styling/page-16) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-17.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-17.md
@@ -11,5 +11,5 @@ Callout 元数据: "tilt-all"
 > The content will be tilted
 ```
 
-> ["tilt-content"](../content-styling/page-7) 和 ["tilt-title"](../title-styling/page-17) 的简写
+> ["tilt-content"](../../content-styling/page-7) 和 ["tilt-title"](../../title-styling/page-17) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-18.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-18.md
@@ -11,4 +11,4 @@ Callout 元数据: "italic-all"
 > The content will be displayed as italic
 ```
 
-> ["italic-content"](../content-styling/page-8) 和 ["italic-title"](../title-styling/page-18) 的简写
+> ["italic-content"](../../content-styling/page-8) 和 ["italic-title"](../../title-styling/page-18) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-19.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-19.md
@@ -11,4 +11,4 @@ Callout 元数据: "oblique-all"
 > The content will be displayed as oblique
 ```
 
-> ["oblique-content"](../content-styling/page-9) 和 ["oblique-title"](../title-styling/page-19) 的简写
+> ["oblique-content"](../../content-styling/page-9) 和 ["oblique-title"](../../title-styling/page-19) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-2.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-2.md
@@ -9,4 +9,4 @@ Callout 元数据: "all-blue"
 > The background color will be blue
 ```
 
-> ["bg-blue"](../bg-styling/page-2) 和 ["title-blue"](../title-styling/page-2) 的简写
+> ["bg-blue"](../../bg-styling/page-2) 和 ["title-blue"](../../title-styling/page-2) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-20.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-20.md
@@ -11,4 +11,4 @@ Callout 元数据: "dashed-all"
 > The content will be displayed as dashed
 ```
 
-> ["dashed-content"](../content-styling/page-10) 和 ["dashed-title"](../title-styling/page-20) 的简写
+> ["dashed-content"](../../content-styling/page-10) 和 ["dashed-title"](../../title-styling/page-20) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-21.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-21.md
@@ -11,4 +11,4 @@ Callout 元数据: "overline-all"
 > The content will be displayed as overline
 ```
 
-> ["overline-content"](../content-styling/page-11) 和 ["overline-title"](../title-styling/page-21) 的简写
+> ["overline-content"](../../content-styling/page-11) 和 ["overline-title"](../../title-styling/page-21) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-22.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-22.md
@@ -11,4 +11,4 @@ Callout 元数据: "underline-all"
 > The content will be displayed as underline
 ```
 
-> ["underline-content"](../content-styling/page-12) 和 ["underline-title"](../title-styling/page-22) 的简写
+> ["underline-content"](../../content-styling/page-12) 和 ["underline-title"](../../title-styling/page-22) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-23.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-23.md
@@ -11,4 +11,4 @@ Callout 元数据: "line-through-all"
 > The content will be displayed as line-through
 ```
 
-> ["line-through-content"](../content-styling/page-13) 和 ["line-through-title"](../title-styling/page-23) 的简写
+> ["line-through-content"](../../content-styling/page-13) 和 ["line-through-title"](../../title-styling/page-23) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-24.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-24.md
@@ -18,4 +18,4 @@ Callout 元数据: "w-`value`-all"
 > Content will have a lighter font weight
 ```
 
-> ["w-`value`-content"](../content-styling/page-14) 和 ["w-`value`-title"](../title-styling/page-24) 的简写
+> ["w-`value`-content"](../../content-styling/page-14) 和 ["w-`value`-title"](../../title-styling/page-24) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-25.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-25.md
@@ -9,4 +9,4 @@ Callout 元数据: "font-interface-all"
 > The text font will also use interface font
 ```
 
-> ["font-inteface-content"](../content-styling/page-15) 和 ["font-interface-title"](../title-styling/page-31) 的简写
+> ["font-inteface-content"](../../content-styling/page-15) 和 ["font-interface-title"](../../title-styling/page-31) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-26.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-26.md
@@ -9,4 +9,4 @@ Callout 元数据: "font-text-all"
 > The text font will also use text font
 ```
 
-> ["font-text-content"](../content-styling/page-16) 和 ["font-text-title"](../title-styling/page-32) 的简写
+> ["font-text-content"](../../content-styling/page-16) 和 ["font-text-title"](../../title-styling/page-32) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-27.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-27.md
@@ -9,4 +9,4 @@ Callout 元数据: "font-monospace-all"
 > The text font will also use monospace font
 ```
 
-> ["font-monospace-content"](../content-styling/page-17) 和 ["font-monospace-title"](../title-styling/page-33) 的简写
+> ["font-monospace-content"](../../content-styling/page-17) 和 ["font-monospace-title"](../../title-styling/page-33) 的简写

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-3.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-3.md
@@ -9,5 +9,5 @@ Callout 元数据: "all-red"
 > The background color will be red
 ```
 
-> ["bg-red"](../bg-styling/page-3) 和 ["title-red"](../title-styling/page-3) 的简写
+> ["bg-red"](../../bg-styling/page-3) 和 ["title-red"](../../title-styling/page-3) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-4.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-4.md
@@ -9,5 +9,5 @@ Callout 元数据: "all-purple"
 > The background color will be purple
 ```
 
-> ["bg-purple"](../bg-styling/page-4) 和 ["title-purple"](../title-styling/page-4) 的简写
+> ["bg-purple"](../../bg-styling/page-4) 和 ["title-purple"](../../title-styling/page-4) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-5.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-5.md
@@ -9,5 +9,5 @@ Callout 元数据: "all-cyan"
 > The background color will be cyan
 ```
 
-> ["bg-cyan"](../bg-styling/page-5) 和 ["title-cyan"](../title-styling/page-5) 的简写
+> ["bg-cyan"](../../bg-styling/page-5) 和 ["title-cyan"](../../title-styling/page-5) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-6.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-6.md
@@ -9,5 +9,5 @@ Callout 元数据: "all-pink"
 > The background color will be pink
 ```
 
-> ["bg-pink"](../bg-styling/page-6) 和 ["title-pink"](../title-styling/page-6) 的简写
+> ["bg-pink"](../../bg-styling/page-6) 和 ["title-pink"](../../title-styling/page-6) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-7.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-7.md
@@ -8,5 +8,5 @@ Callout 元数据: "all-green"
 > [!tip|all-green] Title will be green
 > The background color will be green
 ```
-> ["bg-green"](../bg-styling/page-7) 和 ["title-green"](../title-styling/page-7) 的简写
+> ["bg-green"](../../bg-styling/page-7) 和 ["title-green"](../../title-styling/page-7) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-8.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-8.md
@@ -9,5 +9,5 @@ Callout 元数据: "all-orange"
 > The background color will be orange
 ```
 
-> ["bg-orange"](../bg-styling/page-8) 和 ["title-orange"](../title-styling/page-8) 的简写
+> ["bg-orange"](../../bg-styling/page-8) 和 ["title-orange"](../../title-styling/page-8) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-9.md
+++ b/hugo-site/content/zh/styling/callout-metadata/combined-styling/page-9.md
@@ -9,5 +9,5 @@ Callout 元数据: "all-yellow"
 > The background color will be yellow
 ```
 
-> ["bg-yellow"](../bg-styling/page-9) 和 ["title-yellow"](../title-styling/page-9) 的简写
+> ["bg-yellow"](../../bg-styling/page-9) 和 ["title-yellow"](../../title-styling/page-9) 的简写
 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-1.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-1.md
@@ -11,4 +11,4 @@ Callout 元数据: "rtl-content"
 > The content will be displayed as rtl
 ```
 
-这种风格本身也适用于 ["rtl-all"](../combined-styling/page-11) 和 ["rtl-title"](../title-styling/page-11). 
+这种风格本身也适用于 ["rtl-all"](../../combined-styling/page-11) 和 ["rtl-title"](../../title-styling/page-11). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-10.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-10.md
@@ -11,4 +11,4 @@ Callout 元数据: "dashed-content"
 > The content will be displayed as dashed
 ```
 
-这种风格本身也适用于 ["dashed-all"](../combined-styling/page-20) 和 ["dashed-title"](../title-styling/page-20). 
+这种风格本身也适用于 ["dashed-all"](../../combined-styling/page-20) 和 ["dashed-title"](../../title-styling/page-20). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-11.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-11.md
@@ -11,4 +11,4 @@ Callout 元数据: "overline-content"
 > The content will be displayed as overline
 ```
 
-这种风格本身也适用于 ["overline-all"](../combined-styling/page-21) 和 ["overline-title"](../title-styling/page-21). 
+这种风格本身也适用于 ["overline-all"](../../combined-styling/page-21) 和 ["overline-title"](../../title-styling/page-21). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-12.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-12.md
@@ -10,4 +10,4 @@ Callout 元数据: "underline-content"
 > The content will be displayed as underline
 ```
 
-这种风格本身也适用于 ["underline-all"](../combined-styling/page-22) 和 ["underline-title"](../title-styling/page-22). 
+这种风格本身也适用于 ["underline-all"](../../combined-styling/page-22) 和 ["underline-title"](../../title-styling/page-22). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-13.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-13.md
@@ -11,4 +11,4 @@ Callout 元数据: "line-through-content"
 > The content will be displayed as strikethrough
 ```
 
-这种风格本身也适用于 ["line-through-all"](../combined-styling/page-23) 和 ["line-through-title"](../title-styling/page-23). 
+这种风格本身也适用于 ["line-through-all"](../../combined-styling/page-23) 和 ["line-through-title"](../../title-styling/page-23). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-14.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-14.md
@@ -18,4 +18,4 @@ Callout 元数据: "w-`value`-content"
 > Content will have a bold font weight
 ```
 
-这种风格本身也适用于 ["w-`value`-all"](../combined-styling/page-24) 和 ["w-`value`-title"](../title-styling/page-24). 
+这种风格本身也适用于 ["w-`value`-all"](../../combined-styling/page-24) 和 ["w-`value`-title"](../../title-styling/page-24). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-15.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-15.md
@@ -9,4 +9,4 @@ Callout 元数据: "font-interface-content"
 > The text font will use the interface font
 ```
 
-这种风格本身也适用于 ["font-interface-all"](../combined-styling/page-25) 和 ["font-interface-title"](../title-styling/page-31). 
+这种风格本身也适用于 ["font-interface-all"](../../combined-styling/page-25) 和 ["font-interface-title"](../../title-styling/page-31). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-16.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-16.md
@@ -9,4 +9,4 @@ Callout 元数据: "font-text-content"
 > The text font will use the text font
 ```
 
-这种风格本身也适用于 ["font-text-all"](../combined-styling/page-26) 和 ["font-text-title"](../title-styling/page-32). 
+这种风格本身也适用于 ["font-text-all"](../../combined-styling/page-26) 和 ["font-text-title"](../../title-styling/page-32). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-17.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-17.md
@@ -9,4 +9,4 @@ Callout 元数据: "font-monospace-content"
 > The text font will use the monospace font
 ```
 
-这种风格本身也适用于 ["font-monospace-all"](../combined-styling/page-27) 和 ["font-monospace-title"](../title-styling/page-33). 
+这种风格本身也适用于 ["font-monospace-all"](../../combined-styling/page-27) 和 ["font-monospace-title"](../../title-styling/page-33). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-2.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-2.md
@@ -11,4 +11,4 @@ Callout 元数据: "ltr-content"
 > The content will be displayed as ltr
 ```
 
-这种风格本身也适用于 ["ltr-all"](../combined-styling/page-12) 和 ["ltr-title"](../title-styling/page-12). 
+这种风格本身也适用于 ["ltr-all"](../../combined-styling/page-12) 和 ["ltr-title"](../../title-styling/page-12). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-3.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-3.md
@@ -11,4 +11,4 @@ Callout 元数据: "center-content"
 > The content will be centered
 ```
 
-这种风格本身也适用于 ["center-all"](../combined-styling/page-13) 和 ["center-title"](../title-styling/page-13). 
+这种风格本身也适用于 ["center-all"](../../combined-styling/page-13) 和 ["center-title"](../../title-styling/page-13). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-4.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-4.md
@@ -11,4 +11,4 @@ Callout 元数据: "uppercase-content"
 > The content will be displayed as uppercase
 ```
 
-这种风格本身也适用于 ["uppercase-all"](../combined-styling/page-14) 和 ["uppercase-title"](../title-styling/page-14). 
+这种风格本身也适用于 ["uppercase-all"](../../combined-styling/page-14) 和 ["uppercase-title"](../../title-styling/page-14). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-5.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-5.md
@@ -11,4 +11,4 @@ Callout 元数据: "lowercase-content"
 > The content will be displayed as lowercase
 ```
 
-这种风格本身也适用于 ["lowercase-all"](../combined-styling/page-15) 和 ["lowercase-title"](../title-styling/page-15). 
+这种风格本身也适用于 ["lowercase-all"](../../combined-styling/page-15) 和 ["lowercase-title"](../../title-styling/page-15). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-6.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-6.md
@@ -14,4 +14,4 @@ Callout 元数据: "caps-content"/"capitalize-content"
 > The content will be displayed as caps
 ```
 
-这种风格本身也适用于 ["caps-all"](../combined-styling/page-16) 和 ["caps-title"](../title-styling/page-16). 
+这种风格本身也适用于 ["caps-all"](../../combined-styling/page-16) 和 ["caps-title"](../../title-styling/page-16). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-7.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-7.md
@@ -11,4 +11,4 @@ Callout 元数据: "tilt-content"
 > The content will be tilted
 ```
 
-这种风格本身也适用于 ["tilt-all"](../combined-styling/page-17) 和 ["tilt-title"](../title-styling/page-17). 
+这种风格本身也适用于 ["tilt-all"](../../combined-styling/page-17) 和 ["tilt-title"](../../title-styling/page-17). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-8.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-8.md
@@ -11,4 +11,4 @@ Callout 元数据: "italic-content"
 > The content will be displayed as italic
 ```
 
-这种风格本身也适用于 ["italic-all"](../combined-styling/page-18) 和 ["italic-title"](../title-styling/page-18). 
+这种风格本身也适用于 ["italic-all"](../../combined-styling/page-18) 和 ["italic-title"](../../title-styling/page-18). 

--- a/hugo-site/content/zh/styling/callout-metadata/content-styling/page-9.md
+++ b/hugo-site/content/zh/styling/callout-metadata/content-styling/page-9.md
@@ -11,4 +11,4 @@ Callout 元数据: "oblique-content"
 > The content will be displayed as oblique
 ```
 
-这种风格本身也适用于 ["oblique-all"](../combined-styling/page-19) 和 ["oblique-title"](../title-styling/page-19). 
+这种风格本身也适用于 ["oblique-all"](../../combined-styling/page-19) 和 ["oblique-title"](../../title-styling/page-19). 

--- a/hugo-site/content/zh/styling/callout-metadata/flashcard.md
+++ b/hugo-site/content/zh/styling/callout-metadata/flashcard.md
@@ -12,4 +12,4 @@ Callout 元数据: "flashcard"
 > which will show on hover
 ```
 
-[单击此处](../../../style-settings/editor/callouts#抽认卡标注) 查看配置选项
+[单击此处](../../style-settings/editor/callouts#抽认卡标注) 查看配置选项

--- a/hugo-site/content/zh/styling/callout-metadata/font-size.md
+++ b/hugo-site/content/zh/styling/callout-metadata/font-size.md
@@ -16,7 +16,7 @@ title: 字体大小
 - Medium (中)
 - Large (大)
 
-在 [UI 字体大小设置](../../../style-settings/editor/ui-font-size) 配置.
+在 [UI 字体大小设置](../../style-settings/editor/typography/ui-font-size) 配置.
 
 用法:
 

--- a/hugo-site/content/zh/styling/callout-metadata/icon-styling/page-1.md
+++ b/hugo-site/content/zh/styling/callout-metadata/icon-styling/page-1.md
@@ -16,4 +16,4 @@ Callout 元数据: "no-icon"
 > Content
 ```
 
-这种风格本身也适用于 ["empty"](../combined-styling/page-1) 和 ["no-title"](../title-styling/page-1). 
+这种风格本身也适用于 ["empty"](../../combined-styling/page-1) 和 ["no-title"](../../title-styling/page-1). 

--- a/hugo-site/content/zh/styling/callout-metadata/popup.md
+++ b/hugo-site/content/zh/styling/callout-metadata/popup.md
@@ -12,4 +12,4 @@ Callout 元数据: "$pop"
 > in reading mode, which will show its contents on hover
 ```
 
-[单击此处](../../../style-settings/editor/callouts#弹出式标注) 查看配置选项
+[单击此处](../../style-settings/editor/callouts#弹出式标注) 查看配置选项

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-1.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-1.md
@@ -11,4 +11,4 @@ Callout 元数据: "no-title"
 > Content wil show as usual
 ```
 
-这种风格本身也适用于 ["empty"](../combined-styling/page-1) 和 ["no-icon"](../title-styling/page-1). 
+这种风格本身也适用于 ["empty"](../../combined-styling/page-1) 和 ["no-icon"](../../title-styling/page-1). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-10.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-10.md
@@ -12,6 +12,6 @@ this theme
 > The background color will be as usual
 ```
 
-这种风格本身也适用于 ["all-color1-color2"](../combined-styling/page-10) 和 ["bg-color1-color2"](../title-styling/page-10).
+这种风格本身也适用于 ["all-color1-color2"](../../combined-styling/page-10) 和 ["bg-color1-color2"](../../title-styling/page-10).
 
-需要启用此 ["样式设置" 选项](../../../style-settings/editor/accent-colors#启用扩展调色板).
+需要启用此 ["样式设置" 选项](../../../style-settings/editor/colors/accent-colors#启用扩展调色板).

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-11.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-11.md
@@ -11,4 +11,4 @@ Callout 元数据: "rtl-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["rtl-all"](../combined-styling/page-11) 和 ["rtl-content"](../content-styling/page-1). 
+这种风格本身也适用于 ["rtl-all"](../../combined-styling/page-11) 和 ["rtl-content"](../../content-styling/page-1). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-12.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-12.md
@@ -11,4 +11,4 @@ Callout 元数据: "ltr-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["ltr-all"](../combined-styling/page-12) 和 ["ltr-content"](../content-styling/page-2). 
+这种风格本身也适用于 ["ltr-all"](../../combined-styling/page-12) 和 ["ltr-content"](../../content-styling/page-2). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-13.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-13.md
@@ -11,4 +11,4 @@ Callout 元数据: "center-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["center-all"](../combined-styling/page-13) 和 ["center-content"](../content-styling/page-3). 
+这种风格本身也适用于 ["center-all"](../../combined-styling/page-13) 和 ["center-content"](../../content-styling/page-3). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-14.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-14.md
@@ -11,4 +11,4 @@ Callout 元数据: "uppercase-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["uppercase-all"](../combined-styling/page-14) 和 ["uppercase-content"](../content-styling/page-4). 
+这种风格本身也适用于 ["uppercase-all"](../../combined-styling/page-14) 和 ["uppercase-content"](../../content-styling/page-4). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-15.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-15.md
@@ -11,4 +11,4 @@ Callout 元数据: "lowercase-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["lowercase-all"](../combined-styling/page-15) 和 ["lowercase-content"](../content-styling/page-5). 
+这种风格本身也适用于 ["lowercase-all"](../../combined-styling/page-15) 和 ["lowercase-content"](../../content-styling/page-5). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-16.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-16.md
@@ -14,4 +14,4 @@ Callout 元数据: "caps-title"/"capitalize-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["caps-all"](../combined-styling/page-16) 和 ["caps-content"](../content-styling/page-6). 
+这种风格本身也适用于 ["caps-all"](../../combined-styling/page-16) 和 ["caps-content"](../../content-styling/page-6). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-17.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-17.md
@@ -11,4 +11,4 @@ Callout 元数据: "tilt-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["tilt-all"](../combined-styling/page-17) 和 ["tilt-content"](../content-styling/page-7). 
+这种风格本身也适用于 ["tilt-all"](../../combined-styling/page-17) 和 ["tilt-content"](../../content-styling/page-7). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-18.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-18.md
@@ -11,4 +11,4 @@ Callout 元数据: "italic-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["italic-all"](../combined-styling/page-18) 和 ["italic-content"](../content-styling/page-8). 
+这种风格本身也适用于 ["italic-all"](../../combined-styling/page-18) 和 ["italic-content"](../../content-styling/page-8). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-19.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-19.md
@@ -11,4 +11,4 @@ Callout 元数据: "oblique-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["oblique-all"](../combined-styling/page-19) 和 ["oblique-content"](../content-styling/page-9). 
+这种风格本身也适用于 ["oblique-all"](../../combined-styling/page-19) 和 ["oblique-content"](../../content-styling/page-9). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-2.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-2.md
@@ -9,4 +9,4 @@ Callout 元数据: "title-blue"
 > The background color will display as usual
 ```
 
-这种风格本身也适用于 ["all-blue"](../combined-styling/page-2) 和 ["bg-blue"](../title-styling/page-2). 
+这种风格本身也适用于 ["all-blue"](../../combined-styling/page-2) 和 ["bg-blue"](../../title-styling/page-2). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-20.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-20.md
@@ -11,4 +11,4 @@ Callout 元数据: "dashed-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["dashed-all"](../combined-styling/page-20) 和 ["dashed-content"](../content-styling/page-10). 
+这种风格本身也适用于 ["dashed-all"](../../combined-styling/page-20) 和 ["dashed-content"](../../content-styling/page-10). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-21.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-21.md
@@ -11,4 +11,4 @@ Callout 元数据: "overline-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["overline-all"](../combined-styling/page-21) 和 ["overline-content"](../content-styling/page-11). 
+这种风格本身也适用于 ["overline-all"](../../combined-styling/page-21) 和 ["overline-content"](../../content-styling/page-11). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-22.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-22.md
@@ -11,4 +11,4 @@ Callout 元数据: "underline-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["underline-all"](../combined-styling/page-22) 和 ["underline-content"](../content-styling/page-12). 
+这种风格本身也适用于 ["underline-all"](../../combined-styling/page-22) 和 ["underline-content"](../../content-styling/page-12). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-23.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-23.md
@@ -11,4 +11,4 @@ Callout 元数据: "line-through-title"
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["line-through-all"](../combined-styling/page-23) 和 ["line-through-content"](../content-styling/page-13). 
+这种风格本身也适用于 ["line-through-all"](../../combined-styling/page-23) 和 ["line-through-content"](../../content-styling/page-13). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-24.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-24.md
@@ -19,4 +19,4 @@ reading mode/reading mode
 > Content is shown as usual
 ```
 
-这种风格本身也适用于 ["w-`value`-all"](../combined-styling/page-24) 和 ["w-`value`-content"](../content-styling/page-14). 
+这种风格本身也适用于 ["w-`value`-all"](../../combined-styling/page-24) 和 ["w-`value`-content"](../../content-styling/page-14). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-3.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-3.md
@@ -9,4 +9,4 @@ Callout 元数据: "title-red"
 > The background color will display as usual
 ```
 
-这种风格本身也适用于 ["all-red"](../combined-styling/page-3) 和 ["bg-red"](../title-styling/page-3). 
+这种风格本身也适用于 ["all-red"](../../combined-styling/page-3) 和 ["bg-red"](../../title-styling/page-3). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-31.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-31.md
@@ -9,4 +9,4 @@ Callout 元数据: "font-interface-title"
 > The text font will display as usual
 ```
 
-这种风格本身也适用于 ["font-interface-all"](../combined-styling/page-25) 和 ["font-interface-content"](../content-styling/page-15). 
+这种风格本身也适用于 ["font-interface-all"](../../combined-styling/page-25) 和 ["font-interface-content"](../../content-styling/page-15). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-32.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-32.md
@@ -9,4 +9,4 @@ Callout 元数据: "font-text-title"
 > The text font will display as usual
 ```
 
-这种风格本身也适用于 ["font-text-all"](../combined-styling/page-26) 和 ["font-text-content"](../content-styling/page-16). 
+这种风格本身也适用于 ["font-text-all"](../../combined-styling/page-26) 和 ["font-text-content"](../../content-styling/page-16). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-33.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-33.md
@@ -9,4 +9,4 @@ Callout 元数据: "font-monospace-title"
 > The text font will display as usual
 ```
 
-这种风格本身也适用于 ["font-monospace-all"](../combined-styling/page-27) 和 ["font-monospace-content"](../content-styling/page-17). 
+这种风格本身也适用于 ["font-monospace-all"](../../combined-styling/page-27) 和 ["font-monospace-content"](../../content-styling/page-17). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-4.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-4.md
@@ -9,4 +9,4 @@ Callout 元数据: "title-purple"
 > The background color will display as usual
 ```
 
-这种风格本身也适用于 ["all-purple"](../combined-styling/page-4) 和 ["bg-purple"](../title-styling/page-4). 
+这种风格本身也适用于 ["all-purple"](../../combined-styling/page-4) 和 ["bg-purple"](../../title-styling/page-4). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-5.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-5.md
@@ -9,4 +9,4 @@ Callout 元数据: "title-cyan"
 > The background color will display as usual
 ```
 
-这种风格本身也适用于 ["all-cyan"](../combined-styling/page-5) 和 ["bg-cyan"](../title-styling/page-5). 
+这种风格本身也适用于 ["all-cyan"](../../combined-styling/page-5) 和 ["bg-cyan"](../../title-styling/page-5). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-6.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-6.md
@@ -9,4 +9,4 @@ Callout 元数据: "title-pink"
 > The background color will display as usual
 ```
 
-这种风格本身也适用于 ["all-pink"](../combined-styling/page-6) 和 ["bg-pink"](../title-styling/page-6). 
+这种风格本身也适用于 ["all-pink"](../../combined-styling/page-6) 和 ["bg-pink"](../../title-styling/page-6). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-7.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-7.md
@@ -9,4 +9,4 @@ Callout 元数据: "title-green"
 > The background color will display as usual
 ```
 
-这种风格本身也适用于 ["all-green"](../combined-styling/page-7) 和 ["bg-green"](../title-styling/page-7). 
+这种风格本身也适用于 ["all-green"](../../combined-styling/page-7) 和 ["bg-green"](../../title-styling/page-7). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-8.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-8.md
@@ -9,4 +9,4 @@ Callout 元数据: "title-orange"
 > The background color will display as usual
 ```
 
-这种风格本身也适用于 ["all-orange"](../combined-styling/page-8) 和 ["bg-orange"](../title-styling/page-8). 
+这种风格本身也适用于 ["all-orange"](../../combined-styling/page-8) 和 ["bg-orange"](../../title-styling/page-8). 

--- a/hugo-site/content/zh/styling/callout-metadata/title-styling/page-9.md
+++ b/hugo-site/content/zh/styling/callout-metadata/title-styling/page-9.md
@@ -9,4 +9,4 @@ Callout 元数据: "title-yellow"
 > The background color will display as usual
 ```
 
-这种风格本身也适用于 ["all-yellow"](../combined-styling/page-9) 和 ["bg-yellow"](../title-styling/page-9). 
+这种风格本身也适用于 ["all-yellow"](../../combined-styling/page-9) 和 ["bg-yellow"](../../title-styling/page-9). 

--- a/hugo-site/content/zh/styling/css-classes/heading-indicators/_index.md
+++ b/hugo-site/content/zh/styling/css-classes/heading-indicators/_index.md
@@ -19,4 +19,4 @@ cssclasses:
 ###### I will have an indicator before me
 ```
 
-有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/headings#关于全局启用标题指示器).
+有关全局启用此选项的样式设置等效项, 请 [单击此处](../../style-settings/editor/typography/headings#关于全局启用标题指示器).

--- a/hugo-site/content/zh/styling/css-classes/heading-indicators/page-1.md
+++ b/hugo-site/content/zh/styling/css-classes/heading-indicators/page-1.md
@@ -15,4 +15,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/headings#为标题-1-启用全局标题指示器).
+有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/typography/headings#为标题-1-启用全局标题指示器).

--- a/hugo-site/content/zh/styling/css-classes/heading-indicators/page-2.md
+++ b/hugo-site/content/zh/styling/css-classes/heading-indicators/page-2.md
@@ -15,4 +15,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/headings#为标题-2-启用全局标题指示器).
+有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/typography/headings#为标题-2-启用全局标题指示器).

--- a/hugo-site/content/zh/styling/css-classes/heading-indicators/page-3.md
+++ b/hugo-site/content/zh/styling/css-classes/heading-indicators/page-3.md
@@ -15,4 +15,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/headings#为标题-3-启用全局标题指示器).
+有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/typography/headings#为标题-3-启用全局标题指示器).

--- a/hugo-site/content/zh/styling/css-classes/heading-indicators/page-4.md
+++ b/hugo-site/content/zh/styling/css-classes/heading-indicators/page-4.md
@@ -15,4 +15,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/headings#为标题-4-启用全局标题指示器).
+有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/typography/headings#为标题-4-启用全局标题指示器).

--- a/hugo-site/content/zh/styling/css-classes/heading-indicators/page-5.md
+++ b/hugo-site/content/zh/styling/css-classes/heading-indicators/page-5.md
@@ -15,4 +15,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/headings#为标题-5-启用全局标题指示器).
+有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/typography/headings#为标题-5-启用全局标题指示器).

--- a/hugo-site/content/zh/styling/css-classes/heading-indicators/page-6.md
+++ b/hugo-site/content/zh/styling/css-classes/heading-indicators/page-6.md
@@ -15,4 +15,4 @@ cssclasses:
 Others headings display as usual
 ```
 
-有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/headings#为标题-6-启用全局标题指示器).
+有关全局启用此选项的样式设置等效项, 请 [单击此处](../../../style-settings/editor/typography/headings#为标题-6-启用全局标题指示器).

--- a/hugo-site/content/zh/styling/style-settings/editor/Typography/Headings/_index.md
+++ b/hugo-site/content/zh/styling/style-settings/editor/Typography/Headings/_index.md
@@ -33,7 +33,7 @@ Style Settings
 
 在全局范围内自定义哪些标题前面有标题指示符.
 
-如果您希望按笔记应用它们, 请 [单击此处](../../../../styling/css-classes/heading-indicators).
+如果您希望按笔记应用它们, 请 [单击此处](../../../../css-classes/heading-indicators).
 
 ---
 
@@ -45,7 +45,7 @@ Style Settings
 
 默认: false (类切换)
 
-> CSS 类等效项可以在[这里找到](../../../../styling/css-classes/heading-indicators/page-1)
+> CSS 类等效项可以在[这里找到](../../../../css-classes/heading-indicators/page-1)
 
 ### 标题 1 颜色
 
@@ -120,7 +120,7 @@ Style Settings
 
 默认: false (类切换)
 
-> CSS 类等效项可以在[这里找到](../../../../styling/css-classes/heading-indicators/page-2)
+> CSS 类等效项可以在[这里找到](../../../../css-classes/heading-indicators/page-2)
 
 ### 标题 2 颜色
 
@@ -193,7 +193,7 @@ Style Settings
 
 默认: false (类切换)
 
-> CSS 类等效项可以在[这里找到](../../../../styling/css-classes/heading-indicators/page-3)
+> CSS 类等效项可以在[这里找到](../../../../css-classes/heading-indicators/page-3)
 
 ### 标题 3 颜色
 
@@ -266,7 +266,7 @@ Style Settings
 
 默认: false (类切换)
 
-> CSS 类等效项可以在[这里找到](../../../../styling/css-classes/heading-indicators/page-4)
+> CSS 类等效项可以在[这里找到](../../../../css-classes/heading-indicators/page-4)
 
 ### 标题 4 颜色
 
@@ -339,7 +339,7 @@ Style Settings
 
 默认: false (类切换)
 
-> CSS 类等效项可以在[这里找到](../../../../styling/css-classes/heading-indicators/page-5)
+> CSS 类等效项可以在[这里找到](../../../../css-classes/heading-indicators/page-5)
 
 ### 标题 5 颜色
 
@@ -412,7 +412,7 @@ Style Settings
 
 默认: false (类切换)
 
-> CSS 类等效项可以在[这里找到](../../../../styling/css-classes/heading-indicators/page-6)
+> CSS 类等效项可以在[这里找到](../../../../css-classes/heading-indicators/page-6)
 
 ### 标题 6 颜色
 


### PR DESCRIPTION
<p>I hit a 404 while translating the Korean docs, so I checked the rest of the internal links across all three languages and found a lot more broken ones.</p>
<p>Most of them broke in the 2.0 restructure: editor pages moved under <code>colors/</code>, <code>typography/</code>, and <code>workspace-components/</code>, but the links pointing to them were never updated. Separately, a lot of the <code>callout-metadata</code> cross-links were already off by one directory level. The page URLs have a trailing slash, so <code>../sibling/page-N</code> resolves under the current page instead of next to it.</p>
<p>This PR fixes the <strong>en and zh</strong> docs. The Korean side is handled separately in the full ko 2.0 update, since ko is being restructured there at the same time. Keeping ko out of this PR avoids overlapping edits between the two.</p>
<h3>What's broken (live site)</h3>
<p>Each of these links leads to a 404 because the target page moved during the restructure. It's the same 404 page in every case, shown here paired with the page the link is on.</p>

Link (on this page) | Where it lands
-- | --
<img width="1919" height="1039" alt="image" src="https://github.com/user-attachments/assets/bac47238-8a7d-4405-9092-2fdb4c074e7d" /> | <img width="1918" height="1038" alt="image" src="https://github.com/user-attachments/assets/502216a9-7939-4e27-8319-f310307d1476" />
<img width="1917" height="1039" alt="image" src="https://github.com/user-attachments/assets/8e7c909f-02a0-4e7d-b4e9-94f9c08f0def" /> | <img width="1916" height="1040" alt="image" src="https://github.com/user-attachments/assets/9eaca062-80bb-4a18-b8f8-51cecb134a98" />

### What changed
 
- Updated links that pointed to old (pre-restructure) editor paths → their new locations.
- Corrected relative depth on `callout-metadata` sibling cross-links and a few other links that were resolving one level short.
Only link paths were changed. No translated text was touched (verified via word-diff). 186 files, +282/−282 (en and zh).
 
### After the fix (local build)
 
Same two links now resolve to the correct pages:
 
| Link (on this page) | Where it lands now |
|---|---|
| <img width="1915" height="1039" alt="image" src="https://github.com/user-attachments/assets/d9671aae-f998-4c73-ae1a-4efbe63aad64" /> | <img width="1916" height="1039" alt="image" src="https://github.com/user-attachments/assets/91fbcbbf-80f8-46b8-8b66-67be4dbef050" /> |
| <img width="1916" height="1037" alt="image" src="https://github.com/user-attachments/assets/bf311156-6602-4eb2-9d53-316fd189112c" /> | <img width="1914" height="1037" alt="image" src="https://github.com/user-attachments/assets/8caaaac4-cba4-4745-880d-0d9b0a8a63f5" /> |
